### PR TITLE
Accept multiple arguments for !rank and karma operations

### DIFF
--- a/vilebot/src/com/oldterns/vilebot/handlers/user/Karma.java
+++ b/vilebot/src/com/oldterns/vilebot/handlers/user/Karma.java
@@ -83,14 +83,19 @@ public class Karma
                 nicks.add( BaseNick.toBaseNick( nickMatcher.group( 1 ) ) );
             }
 
+            boolean insult = false;
+
             for ( String nick : nicks )
             {
                 if ( !nick.equals( sender ) )
                     KarmaDB.modNounKarma( nick, 1 );
                 else
-                    // TODO insult generator?
-                    event.reply( "I think I'm supposed to insult you now." );
+                    insult = true;
             }
+
+            if ( insult )
+                // TODO insult generator?
+                event.reply( "I think I'm supposed to insult you now." );
         }
     }
 
@@ -112,14 +117,19 @@ public class Karma
                 nicks.add( BaseNick.toBaseNick( nickMatcher.group( 1 ) ) );
             }
 
+            boolean insult = false;
+
             for ( String nick : nicks )
             {
                 if ( !nick.equals( bot.getNick() ) )
                     KarmaDB.modNounKarma( nick, -1 );
                 else
-                    // TODO insult generator?
-                    event.reply( "I think I'm supposed to insult you now." );
+                    insult = true;
             }
+
+            if ( insult )
+                // TODO insult generator?
+                event.reply( "I think I'm supposed to insult you now." );
         }
     }
 


### PR DESCRIPTION
Commits 1fa7af1, 19ea105, a6ccfe3,  4a1b693:
Allow multiple names after !rank, returning each name with its karma ranking one line at a time. Main commit is 1fa7af1.

Much of the code was modified from /handlers/user/Userlists.java, so these commits mostly reuse code that was already present in the codebase.

Commit 6ef0fa9 reverts 9401f69; that part of the regex appeared unnecessary at first but is important.

Input:

> !rank foo bar

Output:

> foo has no karma
> bar is ranked at #25 with 8 points of karma.

Commits f5ad9f1, 9e9e1a5, d302f0d, 84d7d79, 0315b8a:
Allow any combination of ++ and -- operations on a line of input, disregarding any words on the line not ending in ++ or --. Code was fully functional but messy in commit d302f0d, so I streamlined karmaInc and karmaDec in commit 84d7d79 before making the pull request.

This code also takes from Userlists.java, with some modifications to account for the fact that there may be words before, between, or after different karma events. This includes taking Matcher.group(0) rather than Matcher.group(1) of a message where a match is found, and testing the entire message text for matches for karma events. The code works with any combination of karma events and non-karma events on a single line. 

Input:

> foo is greater than bar. foo++ bar--
> !rank foo bar

Output:

> foo is ranked at #42 with 1 points of karma.
> bar is ranked at #28 with 7 points of karma.
