### PR TITLE
Update string-similarity version

### DIFF
--- a/vilebot/pom.xml
+++ b/vilebot/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>info.debatty</groupId>
       <artifactId>java-string-similarity</artifactId>
-      <version>RELEASE</version>
+      <version>0.17</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Update string similarity version to include fix for comparing empty strings. This fixes issues from comparing empty jeopardy answers.