### PR TITLE
Add Travis CI functionality to VileBot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk: oraclejdk8
+before_install:
+          - git clone https://github.com/ASzc/keratin-irc.git
+install: true
+script: mvn package
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk: oraclejdk8
 before_install:
-          - git clone https://github.com/ASzc/keratin-irc.git
+    - git clone https://github.com/ASzc/keratin-irc.git
 install: true
 script: mvn package
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
-jdk: oraclejdk8
+dist: trusty
+jdk: openjdk8
 before_install:
     - git clone https://github.com/ASzc/keratin-irc.git
 install: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vilebot
-[![Build Status](https://travis-ci.org/aptmac/VileBot.svg?branch=travis-ci)](https://travis-ci.org/aptmac/VileBot)
+[![Build Status](https://travis-ci.org/oldterns/VileBot.svg?branch=master)](https://travis-ci.org/oldterns/VileBot)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Vilebot
+[![Build Status](https://travis-ci.org/aptmac/VileBot.svg?branch=travis-ci)](https://travis-ci.org/aptmac/VileBot)
 
 ## Setup
 


### PR DESCRIPTION
This PR is in response to issue #51.

I have attached a link to a test build that I ran on my branch [1], to show the result. A .travis.yml file has been added with instructions as to how VileBot should be built, and a build status badge has been added to the readme.

To finish setting up Travis, @itpun will have to sign into https://travis-ci.org/ using GitHub, and enable Travis to run on VileBot. There are settings that can be toggled for functionality such as cron jobs, and enabling builds on PRs.

[0] https://travis-ci.org/aptmac/VileBot/builds/238490977