### PR TITLE
Added Karmalytics

### DIFF
--- a/vilebot/cfg/vilebot.conf.example
+++ b/vilebot/cfg/vilebot.conf.example
@@ -3,6 +3,8 @@ logLevel=TRACE
 redisHost=localhost
 redisPort=6300
 
+timezone=America/Toronto
+
 ircBotAmount=1
 
 ircUser1=ExampleBot

--- a/vilebot/pom.xml
+++ b/vilebot/pom.xml
@@ -17,8 +17,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/vilebot/src/main/java/com/oldterns/vilebot/db/KarmaDB.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/db/KarmaDB.java
@@ -21,7 +21,7 @@ public class KarmaDB
      * @param noun The noun to change the karma of
      * @param mod The amount to change the karma by, may be negative.
      */
-    public static void modNounKarma( String noun, int mod )
+    protected static void modNounKarma( String noun, int mod )
     {
         Jedis jedis = pool.getResource();
         try

--- a/vilebot/src/main/java/com/oldterns/vilebot/db/KarmalyticsDB.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/db/KarmalyticsDB.java
@@ -1,0 +1,188 @@
+package com.oldterns.vilebot.db;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.oldterns.vilebot.Vilebot;
+import com.oldterns.vilebot.karmalytics.HasKarmalytics;
+import com.oldterns.vilebot.karmalytics.KarmalyticsRecord;
+import redis.clients.jedis.Jedis;
+
+public class KarmalyticsDB
+    extends RedisDB
+{
+    private final static TimeZone TIME_ZONE = TimeZone.getTimeZone( Vilebot.getConfig().get( "timezone" ) );
+
+    private final static String KA_KEY = "karmalytics";
+
+    private final static Map<String, List<String>> karmalyticsIdToGroups = new HashMap<>();
+
+    private final static Map<String, Set<String>> karmalyticsGroupToMemberIds = new HashMap<>();
+
+    private final static Map<String, Function<KarmalyticsRecord, String>> karmalyticsIdToDescriptorFunctions =
+        new HashMap<>();
+
+    // A record has the size of `length of timestamp + length of nick + length of id
+    // + length of descriptor + size of
+    // karma mod + size of score
+    // + 4`
+    // length on timestamp will be between 21 and 31 (see ISO Timestamps),
+    // length of nick will be around 8
+    // length of id be around 10
+    // length of karma mod will be around 5
+    // score is a double, so it will be 8 bytes
+    // so the min size would be 31 + 8 + 10 + 5 + 8 + 4 = 64
+    //
+    // 64 * 1000000 = 64, 000, 000 bytes, or 64MB
+    // Unlike the other databases, this one will have a lot of records, so it is
+    // necessary to keep them in check
+    private final static long MAX_RECORDS = 1000000;
+
+    public static Set<String> getSources()
+    {
+        return karmalyticsIdToGroups.keySet();
+    }
+
+    public static Function<KarmalyticsRecord, String> getRecordDescriptorFunctionForSource( String source )
+    {
+        return karmalyticsIdToDescriptorFunctions.get( source );
+    }
+
+    public static Set<String> getGroups()
+    {
+        return karmalyticsGroupToMemberIds.keySet();
+    }
+
+    public static List<String> getGroupsForMember( String member )
+    {
+        return karmalyticsIdToGroups.get( member );
+    }
+
+    public static boolean isMemberInGroup( String member, String group )
+    {
+        return karmalyticsGroupToMemberIds.get( group ).contains( member );
+    }
+
+    public static void intializeKarmalyticsFor( HasKarmalytics hasKarmalytics )
+    {
+        if ( hasKarmalytics.getKarmalyticsId().contains( ">" ) )
+        {
+            throw new IllegalArgumentException( "\">\" is an illegal character in Karmalytics identifiers." );
+        }
+
+        if ( !karmalyticsIdToGroups.containsKey( hasKarmalytics.getKarmalyticsId() ) )
+        {
+
+            karmalyticsIdToGroups.put( hasKarmalytics.getKarmalyticsId(), hasKarmalytics.getGroups() );
+            karmalyticsIdToDescriptorFunctions.put( hasKarmalytics.getKarmalyticsId(),
+                                                    hasKarmalytics.getRecordDescriptorFunction() );
+
+            for ( String group : hasKarmalytics.getGroups() )
+            {
+                karmalyticsGroupToMemberIds.computeIfAbsent( group,
+                                                             k -> new HashSet<>() ).add( hasKarmalytics.getKarmalyticsId() );
+            }
+        }
+    }
+
+    public static void modNounKarma( HasKarmalytics source, Optional<String> extraInfo, String nick, int mod )
+    {
+        if ( !karmalyticsIdToGroups.containsKey( source.getKarmalyticsId() ) )
+        {
+            throw new IllegalStateException( "Karmalytics is not tracking " + source.getKarmalyticsId() );
+        }
+
+        KarmaDB.modNounKarma( nick, mod );
+
+        Jedis jedis = pool.getResource();
+
+        // Check to see if we hit max records, and if so remove the earliest record
+        if ( jedis.zcard( KA_KEY ) > MAX_RECORDS )
+        {
+            jedis.zremrangeByRank( KA_KEY, 0, 0 );
+        }
+        StringBuilder value = new StringBuilder();
+
+        Instant currentTime = Instant.now();
+        value.append( LocalDateTime.ofInstant( currentTime,
+                                               TIME_ZONE.toZoneId().getRules().getOffset( currentTime ) ) ).toString();
+        value.append( ">" );
+        value.append( nick );
+        value.append( ">" );
+        value.append( source.getKarmalyticsId() );
+        value.append( ">" );
+        if ( extraInfo.isPresent() )
+        {
+            value.append( Base64.getEncoder().encodeToString( extraInfo.get().getBytes() ) );
+        }
+        value.append( ">" );
+        if ( mod >= 0 )
+        {
+            value.append( "+" );
+            value.append( mod );
+        }
+        else
+        {
+            value.append( mod );
+        }
+
+        jedis.zadd( KA_KEY, currentTime.toEpochMilli(), value.toString() );
+
+        pool.returnResource( jedis );
+    }
+
+    public static LocalDateTime getTimestampOfFirstRecord()
+    {
+        Jedis jedis = pool.getResource();
+
+        Set<String> record = jedis.zrange( KA_KEY, 0, 0 );
+
+        pool.returnResource( jedis );
+
+        if ( record.isEmpty() )
+        {
+            throw new IndexOutOfBoundsException();
+        }
+
+        return new KarmalyticsRecord( record.stream().findFirst().get() ).getDateTime();
+    }
+
+    public static Set<KarmalyticsRecord> getRecordsBetween( LocalDateTime from, LocalDateTime to )
+    {
+        Jedis jedis = pool.getResource();
+
+        long fromScore = from.toEpochSecond( TIME_ZONE.toZoneId().getRules().getOffset( from ) ) * 1000;
+        long toScore = to.toEpochSecond( TIME_ZONE.toZoneId().getRules().getOffset( to ) ) * 1000;
+
+        Set<KarmalyticsRecord> out =
+            jedis.zrangeByScore( KA_KEY, fromScore,
+                                 toScore ).stream().map( KarmalyticsRecord::new ).collect( Collectors.toSet() );
+
+        pool.returnResource( jedis );
+        return out;
+
+    }
+
+    public static List<KarmalyticsRecord> getRangeByEndRank( long distanceFromEnd, long maxRecordsToFetch )
+    {
+        Jedis jedis = pool.getResource();
+
+        List<KarmalyticsRecord> out =
+            jedis.zrange( KA_KEY, -( distanceFromEnd + maxRecordsToFetch ), -( distanceFromEnd + 1 ) )
+                 // Exploit the fact ISO date-times can be lexicologically sorted
+                 .stream().sorted().map( KarmalyticsRecord::new ).collect( Collectors.toList() );
+        pool.returnResource( jedis );
+        return out;
+    }
+
+}

--- a/vilebot/src/main/java/com/oldterns/vilebot/db/PasswordDB.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/db/PasswordDB.java
@@ -20,9 +20,12 @@ public class PasswordDB
 
     private static final String keyOfPassSaltsHash = "password-salts";
 
-    // Note, there is some overlap in terms between the crypto term "Secure Hash" and the Redis structure "Hash". Redis
-    // hashes are maps, though called hashes because of a common method of implementing them via a hash function. Except
-    // for keyOfPassHash and keyOfPassSaltsHash, every use of "hash" in this file refers to the cryptography term.
+    // Note, there is some overlap in terms between the crypto term "Secure Hash"
+    // and the Redis structure "Hash". Redis
+    // hashes are maps, though called hashes because of a common method of
+    // implementing them via a hash function. Except
+    // for keyOfPassHash and keyOfPassSaltsHash, every use of "hash" in this file
+    // refers to the cryptography term.
 
     /**
      * @return A long random string
@@ -114,8 +117,10 @@ public class PasswordDB
             Transaction trans;
             do
             {
-                // Can't use intermediate results of a Redis transaction in that transaction, so watch the keys and do
-                // the query before opening the transaction. The transaction will fail on exec() call if the keys
+                // Can't use intermediate results of a Redis transaction in that transaction, so
+                // watch the keys and do
+                // the query before opening the transaction. The transaction will fail on exec()
+                // call if the keys
                 // changed.
                 jedis.watch( keyOfPassHash, keyOfPassSaltsHash );
                 boolean exists = jedis.hexists( keyOfPassHash, username );

--- a/vilebot/src/main/java/com/oldterns/vilebot/db/UserlistDB.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/db/UserlistDB.java
@@ -88,9 +88,12 @@ public class UserlistDB
         Jedis jedis = pool.getResource();
         try
         {
-            // KEYS is O(n) operation, so it won't scale propery for large numbers of database keys.
-            // We're going to use it here however, as the number of keys in our database should never get large enough
-            // for this to matter, and the alternative of maintaining a set of userlists has the potential to be buggy.
+            // KEYS is O(n) operation, so it won't scale propery for large numbers of
+            // database keys.
+            // We're going to use it here however, as the number of keys in our database
+            // should never get large enough
+            // for this to matter, and the alternative of maintaining a set of userlists has
+            // the potential to be buggy.
             Set<String> rawlists = jedis.keys( keyOfUserlistSetsPrefix + "*" );
 
             Set<String> lists = new HashSet<String>();

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/admin/AdminManagement.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/admin/AdminManagement.java
@@ -30,7 +30,8 @@ public class AdminManagement
             String editedAdminNick = matcher.group( 1 );
             String password = matcher.group( 2 );
 
-            // Note that an empty admin group will allow a setadmin command to succeed (self-bootstrapping)
+            // Note that an empty admin group will allow a setadmin command to succeed
+            // (self-bootstrapping)
 
             String username = Sessions.getSession( sender );
             if ( GroupDB.noAdmins() || GroupDB.isAdmin( username ) )

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/AnswerQuestion.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/AnswerQuestion.java
@@ -1,5 +1,17 @@
 package com.oldterns.vilebot.handlers.user;
 
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import ca.szc.keratin.bot.annotation.HandlerContainer;
 import ca.szc.keratin.core.event.message.recieve.ReceivePrivmsg;
 import com.oldterns.vilebot.Vilebot;
@@ -7,17 +19,6 @@ import net.engio.mbassy.listener.Handler;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
-import java.net.URLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.Scanner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Created by eunderhi on 13/08/15.

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Help.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Help.java
@@ -9,9 +9,9 @@ package com.oldterns.vilebot.handlers.user;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.engio.mbassy.listener.Handler;
 import ca.szc.keratin.bot.annotation.HandlerContainer;
 import ca.szc.keratin.core.event.message.recieve.ReceivePrivmsg;
+import net.engio.mbassy.listener.Handler;
 
 @HandlerContainer
 public class Help
@@ -113,6 +113,11 @@ public class Help
         sb.append( " { !inquisit <noun> }" );
         sb.append( " { !settitle <noun> }" );
         sb.append( " { !topdonors }" );
+        sb.append( " Karmalytics:" );
+
+        sb.append( " { !ka report [nick] [-from date] [-to date] }" );
+        sb.append( " { !ka past number [nick] }" );
+
         return sb.toString();
     }
 }

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Jaziz.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Jaziz.java
@@ -1,5 +1,15 @@
 package com.oldterns.vilebot.handlers.user;
 
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import ca.szc.keratin.bot.annotation.HandlerContainer;
 import ca.szc.keratin.core.event.message.recieve.ReceivePrivmsg;
 import com.oldterns.vilebot.Vilebot;
@@ -7,13 +17,6 @@ import net.engio.mbassy.listener.Handler;
 import twitter4j.JSONArray;
 import twitter4j.JSONException;
 import twitter4j.JSONObject;
-
-import java.io.FileNotFoundException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Created by eunderhi on 27/07/16.

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Kaomoji.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Kaomoji.java
@@ -63,14 +63,9 @@ public class Kaomoji
             {
                 words[0] = "confused";
             }
-
-            else if ( words[0].equals( "nsfw" ) || words[0].equals( "wtf" ) )
+            else if ( words[0].equals( "nsfw" ) | words[0].equals( "wtf" ) )
             {
                 kaomoji = "ⓃⒶⓃⒾ(☉൧ ಠ ꐦ)";
-            }
-            else if ( words[0].equals( "vilebot" ) )
-            {
-                kaomoji = "( ͡° ͜ʖ ͡° )";
             }
             else
             {

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Kaomoji.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Kaomoji.java
@@ -63,9 +63,14 @@ public class Kaomoji
             {
                 words[0] = "confused";
             }
-            else if ( words[0].equals( "nsfw" ) | words[0].equals( "wtf" ) )
+
+            else if ( words[0].equals( "nsfw" ) || words[0].equals( "wtf" ) )
             {
                 kaomoji = "ⓃⒶⓃⒾ(☉൧ ಠ ꐦ)";
+            }
+            else if ( words[0].equals( "vilebot" ) )
+            {
+                kaomoji = "( ͡° ͜ʖ ͡° )";
             }
             else
             {

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Karmalytics.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Karmalytics.java
@@ -1,0 +1,221 @@
+package com.oldterns.vilebot.handlers.user;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import ca.szc.keratin.bot.annotation.HandlerContainer;
+import ca.szc.keratin.core.event.message.recieve.ReceivePrivmsg;
+import com.oldterns.vilebot.db.KarmalyticsDB;
+import com.oldterns.vilebot.karmalytics.KarmalyticsRecord;
+import com.oldterns.vilebot.util.BaseNick;
+import net.engio.mbassy.listener.Handler;
+
+// Formater removes empty lines from javadoc...
+@HandlerContainer
+// Process Karmalytics requests Currently supported requests are:
+//
+// !ka report [nick] [from date] [to date]
+//
+// - Gives a general summary of karma transactions for a specified range
+// (from defaults to one week before to, to defaults to
+// today). If nick is provided, give summary for user with nick instead
+//
+// !ka past number [nick]
+//
+// - Displays the past number karma transactions. If nick was provided, show
+// their last number
+// karma transaction
+//
+public class Karmalytics
+{
+    private static final Pattern PERFORM_KARMALYTIC_PATTERN = Pattern.compile( "!ka (.*)" );
+
+    private static final Pattern REPORT_PATTERN = Pattern.compile( "report( [^-].*?)?( -from .*?)?( -to .*?)?" );
+
+    private static final Pattern PAST_PATTERN = Pattern.compile( "past ([0-9]+)( .*?)?" );
+
+    @Handler
+    public void performKarmalytics( ReceivePrivmsg event )
+    {
+        String text = event.getText();
+        Matcher matcher = PERFORM_KARMALYTIC_PATTERN.matcher( text );
+
+        if ( matcher.matches() )
+        {
+            String request = matcher.group( 1 );
+            processRequest( event, BaseNick.toBaseNick( event.getSender() ), request );
+        }
+    }
+
+    private void processRequest( ReceivePrivmsg event, String nick, String request )
+    {
+        Matcher reportMatcher = REPORT_PATTERN.matcher( request );
+        Matcher pastMatcher = PAST_PATTERN.matcher( request );
+
+        if ( reportMatcher.matches() )
+        {
+            Optional<String> nickToReport = Optional.ofNullable( reportMatcher.group( 1 ) );
+            Optional<String> from = Optional.ofNullable( reportMatcher.group( 2 ) );
+            Optional<String> to = Optional.ofNullable( reportMatcher.group( 3 ) );
+            processReport( event, nickToReport, from, to );
+        }
+        else if ( pastMatcher.matches() )
+        {
+            int numberOfPastTransactionsToFetch = Integer.parseInt( pastMatcher.group( 1 ) );
+            Optional<String> nickToReport = Optional.ofNullable( pastMatcher.group( 2 ) );
+            processPastTransactions( event, numberOfPastTransactionsToFetch, nickToReport );
+        }
+        else
+        {
+            event.reply( "\"" + request + "\" is not a recognized command. See !help for karmalytics command list." );
+        }
+    }
+
+    private void processPastTransactions( ReceivePrivmsg event, int numberOfPastTransactionsToFetch,
+                                          Optional<String> nickToReport )
+    {
+        if ( nickToReport.isPresent() )
+        {
+            String baseNick = BaseNick.toBaseNick( nickToReport.get().substring( 1 ) );
+            List<KarmalyticsRecord> myRecords = new ArrayList<>();
+            for ( int i = 0; myRecords.size() < numberOfPastTransactionsToFetch; i++ )
+            {
+                List<KarmalyticsRecord> records = KarmalyticsDB.getRangeByEndRank( i * 100, 100 );
+                if ( records.isEmpty() )
+                {
+                    break;
+                }
+
+                records.stream().filter( r -> r.getNick().equals( baseNick ) ).forEachOrdered( r -> myRecords.add( r ) );
+            }
+
+            if ( myRecords.isEmpty() )
+            {
+                event.reply( "No karma transactions has occurred yet for " + baseNick + "." );
+            }
+            else
+            {
+                myRecords.stream().limit( numberOfPastTransactionsToFetch ).forEachOrdered( record -> {
+                    event.reply( KarmalyticsDB.getRecordDescriptorFunctionForSource( record.getSource() ).apply( record ) );
+                } );
+            }
+
+        }
+        else
+        {
+            List<KarmalyticsRecord> records = KarmalyticsDB.getRangeByEndRank( 0, numberOfPastTransactionsToFetch );
+
+            if ( records.isEmpty() )
+            {
+                event.reply( "No karma transactions has occurred yet." );
+            }
+            else
+            {
+                for ( KarmalyticsRecord record : records )
+                {
+                    event.reply( KarmalyticsDB.getRecordDescriptorFunctionForSource( record.getSource() ).apply( record ) );
+                }
+            }
+
+        }
+    }
+
+    private void processReport( ReceivePrivmsg event, Optional<String> nick, Optional<String> from,
+                                Optional<String> to )
+    {
+        LocalDateTime fromDateTime;
+        LocalDateTime toDateTime;
+
+        if ( to.isPresent() )
+        {
+            try
+            {
+                toDateTime = LocalDate.parse( to.get().substring( 5 ) ).atStartOfDay();
+            }
+            catch ( DateTimeParseException parseException )
+            {
+                event.reply( "Error in -to date format; format your date following ISO standards (YYYY-MM-DD)" );
+                return;
+            }
+        }
+        else
+        {
+            toDateTime = LocalDate.now().plusDays( 1 ).atStartOfDay();
+        }
+        if ( from.isPresent() )
+        {
+            try
+            {
+
+                fromDateTime = LocalDate.parse( from.get().substring( 7 ) ).atStartOfDay();
+            }
+            catch ( DateTimeParseException parseException )
+            {
+                event.reply( "Error in -from date format; format your date following ISO standards (YYYY-MM-DD)" );
+                return;
+            }
+        }
+        else
+        {
+            fromDateTime = toDateTime.minusWeeks( 1 );
+        }
+
+        Set<KarmalyticsRecord> karmalyticsRecords = KarmalyticsDB.getRecordsBetween( fromDateTime, toDateTime );
+        Map<String, Integer> sourceToKarmaMap = new HashMap<>();
+
+        event.reply( "There are " + karmalyticsRecords.size() + " records" );
+
+        if ( nick.isPresent() )
+        {
+            String baseNick = BaseNick.toBaseNick( nick.get().trim() );
+            for ( KarmalyticsRecord record : karmalyticsRecords )
+            {
+                if ( record.getNick().equals( baseNick ) )
+                {
+                    sourceToKarmaMap.compute( record.getSource(), ( source, karma ) -> ( ( karma != null ) ? karma : 0 )
+                        + record.getKarmaModAmount() );
+                }
+            }
+        }
+        else
+        {
+            for ( KarmalyticsRecord record : karmalyticsRecords )
+            {
+                sourceToKarmaMap.compute( record.getSource(), ( source, karma ) -> ( ( karma != null ) ? karma : 0 )
+                    + record.getKarmaModAmount() );
+            }
+        }
+
+        if ( nick.isPresent() )
+        {
+            event.reply( "Karmalytics report for " + BaseNick.toBaseNick( nick.get().trim() ) + " from "
+                + fromDateTime.toString() + " to " + toDateTime.toString() + ":" );
+        }
+        else
+        {
+            event.reply( "Karmalytics report from " + fromDateTime.toString() + " to " + toDateTime.toString() + ":" );
+        }
+        for ( String source : KarmalyticsDB.getSources() )
+        {
+            StringBuilder line = new StringBuilder();
+            line.append( source );
+            line.append( ": " );
+            int karma = sourceToKarmaMap.getOrDefault( source, 0 );
+            if ( karma > 0 )
+            {
+                line.append( "+" );
+            }
+            line.append( karma );
+            event.reply( line.toString() );
+        }
+    }
+}

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/QuotesAndFacts.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/QuotesAndFacts.java
@@ -155,7 +155,8 @@ public class QuotesAndFacts
 
             try
             {
-                // Case insensitive added automatically, use (?-i) in a message to reenable case sensitivity
+                // Case insensitive added automatically, use (?-i) in a message to reenable case
+                // sensitivity
                 Pattern pattern = Pattern.compile( "(?i)" + regex );
 
                 if ( "fact".equals( mode ) )

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/RockPaperScissors.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/RockPaperScissors.java
@@ -1,28 +1,15 @@
 package com.oldterns.vilebot.handlers.user;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.List;
 import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.oldterns.vilebot.Vilebot;
-import com.oldterns.vilebot.db.KarmaDB;
-import com.oldterns.vilebot.util.BaseNick;
-
-import bsh.EvalError;
-import bsh.Interpreter;
 import ca.szc.keratin.bot.KeratinBot;
 import ca.szc.keratin.bot.annotation.AssignedBot;
 import ca.szc.keratin.bot.annotation.HandlerContainer;
 import ca.szc.keratin.core.event.message.recieve.ReceivePrivmsg;
+import com.oldterns.vilebot.Vilebot;
+import com.oldterns.vilebot.util.BaseNick;
 import net.engio.mbassy.listener.Handler;
 
 /**

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Ttc.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Ttc.java
@@ -1,5 +1,11 @@
 package com.oldterns.vilebot.handlers.user;
 
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import ca.szc.keratin.bot.annotation.HandlerContainer;
 import ca.szc.keratin.core.event.message.recieve.ReceivePrivmsg;
 import net.engio.mbassy.listener.Handler;
@@ -7,12 +13,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.Scanner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Created by eunderhi on 27/10/15.

--- a/vilebot/src/main/java/com/oldterns/vilebot/karmalytics/HasKarmalytics.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/karmalytics/HasKarmalytics.java
@@ -1,0 +1,43 @@
+package com.oldterns.vilebot.karmalytics;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.oldterns.vilebot.db.KarmalyticsDB;
+import com.oldterns.vilebot.util.BaseNick;
+
+public interface HasKarmalytics
+{
+    /**
+     * Returns the groups this HasKarmalytics is in. (Example: Omgword is in "Gaming" and "Omgword")
+     * 
+     * @return the groups this HasKarmalytics is in
+     */
+    List<String> getGroups();
+
+    /**
+     * Returns a unique id that identifies this HasKarmalytics (note: the character ">" is illegal)
+     * 
+     * @return this HasKarmalytics id
+     */
+    String getKarmalyticsId();
+
+    /**
+     * Returns a function that maps KarmalyticsRecord with source `getKarmalyticsId()` to a String that describes the
+     * karma transaction.
+     * 
+     * @return a mapping from this HasKarmalytics records to String
+     */
+    Function<KarmalyticsRecord, String> getRecordDescriptorFunction();
+
+    default void modNounKarma( String nick, int mod )
+    {
+        KarmalyticsDB.modNounKarma( this, Optional.empty(), BaseNick.toBaseNick( nick ), mod );
+    }
+
+    default void modNounKarma( String nick, String extraInfo, int mod )
+    {
+        KarmalyticsDB.modNounKarma( this, Optional.of( extraInfo ), BaseNick.toBaseNick( nick ), mod );
+    }
+}

--- a/vilebot/src/main/java/com/oldterns/vilebot/karmalytics/KarmalyticsRecord.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/karmalytics/KarmalyticsRecord.java
@@ -1,0 +1,52 @@
+package com.oldterns.vilebot.karmalytics;
+
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+public final class KarmalyticsRecord
+{
+    private final LocalDateTime dateTime;
+
+    private final String nick;
+
+    private final String source;
+
+    private final String extraInfo;
+
+    private final int karmaModAmount;
+
+    public KarmalyticsRecord( String record )
+    {
+        String[] fields = record.split( ">" );
+        dateTime = LocalDateTime.parse( fields[0] );
+        nick = fields[1];
+        source = fields[2];
+        extraInfo = new String( Base64.getDecoder().decode( fields[3] ) );
+        karmaModAmount = Integer.parseInt( fields[4] );
+    }
+
+    public LocalDateTime getDateTime()
+    {
+        return dateTime;
+    }
+
+    public String getNick()
+    {
+        return nick;
+    }
+
+    public String getSource()
+    {
+        return source;
+    }
+
+    public String getExtraInfo()
+    {
+        return extraInfo;
+    }
+
+    public int getKarmaModAmount()
+    {
+        return karmaModAmount;
+    }
+}

--- a/vilebot/src/main/java/com/oldterns/vilebot/util/ConfMap.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/util/ConfMap.java
@@ -124,7 +124,8 @@ public class ConfMap
             throw new IllegalArgumentException( "confFile ( " + confFile + " ) points to an existing target, "
                 + "but this target is not a regular file." );
 
-        // Create a BufferedReader from the Path and Charset, then pass to the ConfParser
+        // Create a BufferedReader from the Path and Charset, then pass to the
+        // ConfParser
         try ( BufferedReader reader = Files.newBufferedReader( confFile, charset ) )
         {
             this.entries = parser.parse( reader );


### PR DESCRIPTION
Implements #26. Features two commands so far:

`!ka report [nick] [-from date] [-to date]`: displays how much each different source of karma contributed to the global karma economy (or only for nick if nick is provided) between from and to. from defaults to 1 week before to, to defaults to tommorow. 

`!ka past number [nick]`: displays the past number karma transactions. If nick is provided, show the last number karma transaction that involved nick. 

Since the commands highly relies on redis, it hards to unit test it without mocking it.

I am using the eclipse formatter that was mentioned in the README, but it seems some files got overly formatted.

Known bugs:
-if you have a nick with "|", the nick is not correct in the ++/-- transactions (i.e. it will appears as "nick|status++" instead as of "nick"). Nicks without "|" or special characters do not have this issue. Seems to be an issue either with `Karma.java` or `BaseNick.java` (this issue already exists, but becomes more visible, see #87)