### PR TITLE
Limits number of facts/quotes printed with dump -> Random5 and Print number of quotes/facts

### DIFF
--- a/vilebot/src/main/java/com/oldterns/vilebot/db/QuoteFactDB.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/db/QuoteFactDB.java
@@ -7,6 +7,8 @@
 package com.oldterns.vilebot.db;
 
 import java.util.Set;
+import java.util.LinkedList;
+import java.util.List;
 
 import redis.clients.jedis.Jedis;
 
@@ -17,9 +19,11 @@ public class QuoteFactDB
 
     private static final String keyOfFactSetsPrefix = "noun-facts-";
 
+    private static final int COUNT = 5;
+
     /**
      * Add a quote to the quote set of a noun.
-     * 
+     *
      * @param noun The noun to add a quote to
      * @param quote The new quote
      */
@@ -38,7 +42,7 @@ public class QuoteFactDB
 
     /**
      * Get the quotes of a noun.
-     * 
+     *
      * @param noun The noun to get the quotes of
      * @return The set of quotes for the noun
      */
@@ -57,7 +61,7 @@ public class QuoteFactDB
 
     /**
      * Get a random quote from the set of quotes of a noun.
-     * 
+     *
      * @param noun The noun to get the quotes of
      * @return A random quote for the noun
      */
@@ -75,8 +79,52 @@ public class QuoteFactDB
     }
 
     /**
+     * Get the number of quotes associated with a noun.
+     *
+     * @param noun The noun to get the quotes of
+     * @return The number of quotes
+     */
+    public static Long getQuotesLength( String noun )
+    {
+        Jedis jedis = pool.getResource();
+        try
+        {
+            return jedis.scard( keyOfQuoteSetsPrefix + noun );
+        }
+        finally
+        {
+            pool.returnResource( jedis );
+        }
+    }
+
+    /**
+     * Get 5 random quotes from the set of facts of a noun.
+     *
+     * @param noun The noun to get the quotes of
+     * @return A List of 5 random quotes for the noun
+     */
+    public static List<String> getRandQuotes( String noun )
+    {
+        Jedis jedis = pool.getResource();
+        try
+        {
+            List<String> randomQuotes = new LinkedList<String>();
+            for ( int i = 0; i < COUNT; i++ )
+            {
+                String quote = getRandQuote( noun );
+                randomQuotes.add( quote );
+            }
+            return randomQuotes;
+        }
+        finally
+        {
+            pool.returnResource( jedis );
+        }
+    }
+
+    /**
      * Add a fact to the fact set of a noun.
-     * 
+     *
      * @param noun The noun to add the fact to
      * @param quote The new quote
      */
@@ -95,7 +143,7 @@ public class QuoteFactDB
 
     /**
      * Get the facts of a noun.
-     * 
+     *
      * @param noun The noun to get the facts of
      * @return The set of facts for the noun
      */
@@ -114,7 +162,7 @@ public class QuoteFactDB
 
     /**
      * Get a random fact from the set of facts of a noun.
-     * 
+     *
      * @param noun The noun to get the facts of
      * @return A random fact for the noun
      */
@@ -124,6 +172,50 @@ public class QuoteFactDB
         try
         {
             return jedis.srandmember( keyOfFactSetsPrefix + noun );
+        }
+        finally
+        {
+            pool.returnResource( jedis );
+        }
+    }
+
+    /**
+     * Get the number of facts associated with a noun.
+     *
+     * @param noun The noun to get the facts of
+     * @return The number of facts
+     */
+    public static Long getFactsLength( String noun )
+    {
+        Jedis jedis = pool.getResource();
+        try
+        {
+            return jedis.scard( keyOfFactSetsPrefix + noun );
+        }
+        finally
+        {
+            pool.returnResource( jedis );
+        }
+    }
+
+    /**
+     * Get 5 random facts from the set of facts of a noun.
+     *
+     * @param noun The noun to get the facts of
+     * @return A List of 5 random facts for the noun
+     */
+    public static List<String> getRandFacts( String noun )
+    {
+        Jedis jedis = pool.getResource();
+        try
+        {
+            List<String> randomFacts = new LinkedList<String>();
+            for ( int i = 0; i < COUNT; i++ )
+            {
+                String fact = getRandFact( noun );
+                randomFacts.add( fact );
+            }
+            return randomFacts;
         }
         finally
         {

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Help.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/Help.java
@@ -83,12 +83,16 @@ public class Help
         sb.append( "  Facts/Quotes:" );
         sb.append( " { !fact <noun> }" );
         sb.append( " { !quote <noun> }" );
+        sb.append( " { !factrandom5 <noun> }" );
+        sb.append( " { !quoterandom5 <noun> }" );
         sb.append( " { !factdump <noun> }" );
         sb.append( " { !quotedump <noun> }" );
         sb.append( " { !factadd <noun> <quote> }" );
         sb.append( " { !quoteadd <noun> <quote> }" );
         sb.append( " { !factsearch <noun> <regex> }" );
         sb.append( " { !quotesearch <noun> <regex> }" );
+        sb.append( " { !factnumber <noun> }" );
+        sb.append( " { !quotenumber <noun> }" );
         sb.append( "\n" );
         sb.append( "  Utility:" );
         sb.append( " { s/foo/bar[/[g] [<noun>]] }" );

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/QuotesAndFacts.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/QuotesAndFacts.java
@@ -90,26 +90,50 @@ public class QuotesAndFacts
 
             if ( "fact".equals( mode ) )
             {
-                Set<String> allFacts = QuoteFactDB.getFacts( queried );
-                if ( allFacts.isEmpty() )
+                Long factsLength = QuoteFactDB.getFactsLength( queried );
+                if ( factsLength == 0 )
                 {
                     event.replyPrivately( queried + " has no facts." );
                 }
-                for ( String fact : allFacts )
+                else if ( factsLength <= 5 )
                 {
-                    event.replyPrivately( formatFactReply( queried, fact ) );
+                    Set<String> allFacts = QuoteFactDB.getFacts( queried );
+                    for ( String fact : allFacts )
+                    {
+                        event.replyPrivately( formatFactReply( queried, fact ) );
+                    }
+                }
+                else
+                {
+                    List<String> randomFacts = QuoteFactDB.getRandFacts( queried );
+                    for ( String fact : randomFacts )
+                    {
+                        event.replyPrivately( formatFactReply( queried, fact ) );
+                    }
                 }
             }
             else
             {
-                Set<String> allQuotes = QuoteFactDB.getQuotes( queried );
-                if ( allQuotes.isEmpty() )
+                Long quotesLength = QuoteFactDB.getQuotesLength( queried );
+                if ( quotesLength == 0 )
                 {
                     event.replyPrivately( queried + " has no quotes." );
                 }
-                for ( String quote : allQuotes )
+                else if ( quotesLength <= 5 )
                 {
-                    event.replyPrivately( formatFactReply( queried, quote ) );
+                    Set<String> allQuotes = QuoteFactDB.getQuotes( queried );
+                    for ( String quote : allQuotes )
+                    {
+                        event.replyPrivately( formatQuoteReply( queried, quote ) );
+                    }
+                }
+                else
+                {
+                    List<String> randomQuote = QuoteFactDB.getRandQuotes( queried );
+                    for ( String quote : randomQuote )
+                    {
+                        event.replyPrivately( formatQuoteReply( queried, quote ) );
+                    }
                 }
             }
         }
@@ -301,7 +325,7 @@ public class QuotesAndFacts
 
     /**
      * Removes all specified leading and trailing characters in the array charsToRemove.
-     * 
+     *
      * @param input The string to process
      * @param charsToRemove All characters to remove, treated as a set
      * @return A copy of the input String with the characters removed

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/QuotesAndFacts.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/QuotesAndFacts.java
@@ -37,6 +37,10 @@ public class QuotesAndFacts
 
     private static final Pattern dumpPattern = Pattern.compile( "^!(fact|quote)dump (" + nounPattern + ")\\s*$" );
 
+    private static final Pattern randomPattern = Pattern.compile( "^!(fact|quote)random5 (" + nounPattern + ")\\s*$" );
+
+    private static final Pattern numPattern = Pattern.compile( "^!(fact|quote)number (" + nounPattern + ")\\s*$" );
+
     private static final Pattern queryPattern = Pattern.compile( "^!(fact|quote) (" + nounPattern + ")\\s*$" );
 
     private static final Pattern searchPattern = Pattern.compile( "^!(fact|quote)search (" + nounPattern + ") (.*)$" );
@@ -90,6 +94,43 @@ public class QuotesAndFacts
 
             if ( "fact".equals( mode ) )
             {
+                Set<String> allFacts = QuoteFactDB.getFacts( queried );
+                if ( allFacts.isEmpty() )
+                {
+                    event.replyPrivately( queried + " has no facts." );
+                }
+                for ( String fact : allFacts )
+                {
+                    event.replyPrivately( formatFactReply( queried, fact ) );
+                }
+            }
+            else
+            {
+                Set<String> allQuotes = QuoteFactDB.getQuotes( queried );
+                if ( allQuotes.isEmpty() )
+                {
+                    event.replyPrivately( queried + " has no quotes." );
+                }
+                for ( String quote : allQuotes )
+                {
+                    event.replyPrivately( formatFactReply( queried, quote ) );
+                }
+            }
+        }
+    }
+
+    @Handler
+    private void factQuoteRandomDump( ReceivePrivmsg event )
+    {
+        Matcher matcher = randomPattern.matcher( event.getText() );
+
+        if ( matcher.matches() )
+        {
+            String mode = matcher.group( 1 );
+            String queried = BaseNick.toBaseNick( matcher.group( 2 ) );
+
+            if ( "fact".equals( mode ) )
+            {
                 Long factsLength = QuoteFactDB.getFactsLength( queried );
                 if ( factsLength == 0 )
                 {
@@ -134,6 +175,42 @@ public class QuotesAndFacts
                     {
                         event.replyPrivately( formatQuoteReply( queried, quote ) );
                     }
+                }
+            }
+        }
+    }
+
+    @Handler
+    private void factQuoteNum( ReceivePrivmsg event )
+    {
+        Matcher matcher = numPattern.matcher( event.getText() );
+
+        if ( matcher.matches() )
+        {
+            String mode = matcher.group( 1 );
+            String queried = BaseNick.toBaseNick( matcher.group( 2 ) );
+            if ( "fact".equals( mode ) )
+            {
+                Long factsLength = QuoteFactDB.getFactsLength( queried );
+                if ( factsLength == 0 )
+                {
+                    event.replyPrivately( queried + " has no facts." );
+                }
+                else
+                {
+                    event.replyPrivately( queried + " has " + factsLength + " facts." );
+                }
+            }
+            else
+            {
+                Long quotesLength = QuoteFactDB.getQuotesLength( queried );
+                if ( quotesLength == 0 )
+                {
+                    event.replyPrivately( queried + " has no quotes." );
+                }
+                else
+                {
+                    event.replyPrivately( queried + " has " + quotesLength + " quotes." );
                 }
             }
         }


### PR DESCRIPTION
Particular entries in the database have come to have a large amount of facts/quotes associated with them. It is hard on Vilebot1 when these people are quote/fact dumped and often causes significant lag in Vilebot's response time.
This is not a perfect solution but should offer some relief. This will pull 5 random quotes/facts from a user's database and print them. There is not, however, a check for whether these are the same 5 random quotes/facts so it is possible that the same 5 quotes could be printed on any given call of the quote/fact dump command. Still, I think this is better than the current model!