### PR TITLE
Patch !news and !fakenews commands

### DIFF
--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/FakeNews.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/FakeNews.java
@@ -7,6 +7,8 @@
 
 package com.oldterns.vilebot.handlers.user;
 
+import com.oldterns.vilebot.Vilebot;
+import com.oldterns.vilebot.util.LimitCommand;
 import com.oldterns.vilebot.util.NewsParser;
 import org.apache.log4j.Logger;
 import org.pircbotx.hooks.types.GenericMessageEvent;
@@ -47,11 +49,15 @@ public class FakeNews
         }
     }
 
-    private static final Pattern FAKE_NEWS_PATTERN = Pattern.compile( "^!fakenews(?: ([a-zA-Z]{2,})|)" );
+    private static final Pattern FAKE_NEWS_PATTERN = Pattern.compile( "^!fakenews(?: ([a-zA-Z]+)|)" );
 
     private static final Pattern FAKE_NEWS_HELP_PATTERN = Pattern.compile( "^!fakenews help" );
 
     private final String HELP_MESSAGE = generateHelpMessage();
+
+    private static LimitCommand limitCommand = new LimitCommand();
+
+    private static final String RESTRICTED_CHANNEL = Vilebot.getConfig().get( "ircChannel1" );
 
     @Override
     public void onGenericMessage( final GenericMessageEvent event )
@@ -69,7 +75,7 @@ public class FakeNews
         }
         else if ( matcher.matches() )
         {
-            currentNews( event, matcher, fakeNewsFeedsByCategory, DEFAULT_CATEGORY, logger );
+            newsLimit( event, matcher, fakeNewsFeedsByCategory, DEFAULT_CATEGORY, logger, limitCommand, RESTRICTED_CHANNEL );
         }
     }
 

--- a/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/News.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/handlers/user/News.java
@@ -7,6 +7,8 @@
 
 package com.oldterns.vilebot.handlers.user;
 
+import com.oldterns.vilebot.Vilebot;
+import com.oldterns.vilebot.util.LimitCommand;
 import com.oldterns.vilebot.util.NewsParser;
 import org.apache.log4j.Logger;
 import org.pircbotx.hooks.types.GenericMessageEvent;
@@ -33,6 +35,8 @@ public class News
             newsFeedsByCategory.put( "top", new URL( "https://rss.cbc.ca/lineup/topstories.xml" ) );
             newsFeedsByCategory.put( "world", new URL( "https://rss.cbc.ca/lineup/world.xml" ) );
             newsFeedsByCategory.put( "canada", new URL( "https://rss.cbc.ca/lineup/canada.xml" ) );
+            newsFeedsByCategory.put( "usa", new URL( "http://feeds.reuters.com/Reuters/domesticNews" ) );
+            newsFeedsByCategory.put( "britain", new URL( "http://feeds.bbci.co.uk/news/uk/rss.xml" ) );
             newsFeedsByCategory.put( "politics", new URL( "https://rss.cbc.ca/lineup/politics.xml" ) );
             newsFeedsByCategory.put( "business", new URL( "https://rss.cbc.ca/lineup/business.xml" ) );
             newsFeedsByCategory.put( "health", new URL( "https://rss.cbc.ca/lineup/health.xml" ) );
@@ -74,11 +78,15 @@ public class News
         }
     }
 
-    private static final Pattern NEWS_PATTERN = Pattern.compile( "^!news(?: ([a-zA-Z]{2,})|)" );
+    private static final Pattern NEWS_PATTERN = Pattern.compile( "^!news(?: ([a-zA-Z]+)|)" );
 
     private static final Pattern NEWS_HELP_PATTERN = Pattern.compile( "^!news help" );
 
     private final String HELP_MESSAGE = generateHelpMessage();
+
+    private static LimitCommand limitCommand = new LimitCommand();
+
+    private static final String RESTRICTED_CHANNEL = Vilebot.getConfig().get( "ircChannel1" );
 
     @Override
     public void onGenericMessage( final GenericMessageEvent event )
@@ -96,7 +104,7 @@ public class News
         }
         else if ( matcher.matches() )
         {
-            currentNews( event, matcher, newsFeedsByCategory, DEFAULT_CATEGORY, logger );
+            newsLimit( event, matcher, newsFeedsByCategory, DEFAULT_CATEGORY, logger, limitCommand, RESTRICTED_CHANNEL );
         }
     }
 

--- a/vilebot/src/main/java/com/oldterns/vilebot/util/NewsParser.java
+++ b/vilebot/src/main/java/com/oldterns/vilebot/util/NewsParser.java
@@ -14,6 +14,7 @@ import com.sun.syndication.io.SyndFeedInput;
 import com.sun.syndication.io.XmlReader;
 import org.apache.log4j.Logger;
 import org.pircbotx.hooks.ListenerAdapter;
+import org.pircbotx.hooks.events.MessageEvent;
 import org.pircbotx.hooks.types.GenericMessageEvent;
 
 import java.io.IOException;
@@ -25,7 +26,29 @@ import java.util.regex.Matcher;
 public abstract class NewsParser
     extends ListenerAdapter
 {
-    protected static final int NUM_HEADLINES = 5;
+    protected static final int NUM_HEADLINES = 3;
+
+    protected void newsLimit( GenericMessageEvent event, Matcher matcher, HashMap<String, URL> newsFeedsByCategory,
+                              String defaultCategory, Logger logger, LimitCommand limitCommand, String restrictedChannel )
+    {
+        if ( event instanceof MessageEvent
+            && ( (MessageEvent) event ).getChannel().getName().equals( restrictedChannel ) )
+        {
+            String isLimit = limitCommand.addUse( event.getUser().getNick() );
+            if ( isLimit.isEmpty() )
+            {
+                currentNews( event, matcher, newsFeedsByCategory, defaultCategory, logger );
+            }
+            else
+            {
+                event.respondWith( isLimit );
+            }
+        }
+        else
+        {
+            currentNews( event, matcher, newsFeedsByCategory, defaultCategory, logger );
+        }
+    }
 
     protected void currentNews( GenericMessageEvent event, Matcher matcher, HashMap<String, URL> newsFeedsByCategory,
                                 String defaultCategory, Logger logger )
@@ -65,7 +88,8 @@ public abstract class NewsParser
 
         for ( int i = 0; i < NUM_HEADLINES; i++ )
         {
-            event.respondWith( entries.get( i ).getTitle() + " -> " + entries.get( i ).getLink() );
+            event.respondWith( Colors.bold( "  " + entries.get( i ).getTitle() ) + " -> "
+                + entries.get( i ).getLink() );
         }
     }
 

--- a/vilebot/src/test/java/vilebot/handlers/user/FakeNewsTest.java
+++ b/vilebot/src/test/java/vilebot/handlers/user/FakeNewsTest.java
@@ -8,7 +8,6 @@
 package vilebot.handlers.user;
 
 import com.oldterns.vilebot.handlers.user.FakeNews;
-import com.oldterns.vilebot.handlers.user.News;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -84,7 +83,7 @@ public class FakeNewsTest
         when( event.getMessage() ).thenReturn( ircmsg );
         fakeNewsClass.onGenericMessage( event );
 
-        verify( event, times( 5 ) ).respondWith( notNull() );
+        verify( event, times( 3 ) ).respondWith( notNull() );
     }
 
     @Test
@@ -95,6 +94,6 @@ public class FakeNewsTest
         when( event.getMessage() ).thenReturn( ircmsg );
         fakeNewsClass.onGenericMessage( event );
 
-        verify( event, times( 5 ) ).respondWith( notNull() );
+        verify( event, times( 3 ) ).respondWith( notNull() );
     }
 }

--- a/vilebot/src/test/java/vilebot/handlers/user/NewsTest.java
+++ b/vilebot/src/test/java/vilebot/handlers/user/NewsTest.java
@@ -45,6 +45,8 @@ public class NewsTest
         sb.append( " { top }" );
         sb.append( " { world }" );
         sb.append( " { canada }" );
+        sb.append( " { usa }" );
+        sb.append( " { britain }" );
         sb.append( " { politics }" );
         sb.append( " { business }" );
         sb.append( " { health }" );
@@ -109,7 +111,7 @@ public class NewsTest
         when( event.getMessage() ).thenReturn( ircmsg );
         newsClass.onGenericMessage( event );
 
-        verify( event, times( 5 ) ).respondWith( notNull() );
+        verify( event, times( 3 ) ).respondWith( notNull() );
     }
 
     @Test
@@ -120,6 +122,6 @@ public class NewsTest
         when( event.getMessage() ).thenReturn( ircmsg );
         newsClass.onGenericMessage( event );
 
-        verify( event, times( 5 ) ).respondWith( notNull() );
+        verify( event, times( 3 ) ).respondWith( notNull() );
     }
 }


### PR DESCRIPTION
Patches #127. This patch adds a LimitCommand to !news and !fakenews, limiting the user to two uses every five minutes. Uses of either command would count as a use (help commands are excluded). Formats the headlines for readability.